### PR TITLE
Limit display height

### DIFF
--- a/app.py
+++ b/app.py
@@ -90,5 +90,6 @@ df_config = {
 }
 st.dataframe(
   data_df,
-  column_config=df_config
+  column_config=df_config,
+  height=400
 )


### PR DESCRIPTION
Fixes #14. As all records must be fetched anyway, there seems to be no logic to showing only ten, then loading others, since they're already in memory; better to limit the height of the data display unless performance suffers considerably enough down the road.